### PR TITLE
add instructions link in path to fellowship

### DIFF
--- a/docs/fellowship/path_to_fellowship.md
+++ b/docs/fellowship/path_to_fellowship.md
@@ -31,7 +31,7 @@ To be eligible for Fellowship, you must demonstrate:
 There are two nomination paths:
 
 - **Self-Nomination**  
-  Submit a short expression of interest to the ONM Secretary, including your past contributions and proposed initiative.  The form for this can be found [here](https://forms.gle/z91YFjgqJ16JXbY37)
+  Submit a short expression of interest to the ONM Secretary, including your past contributions and proposed initiative.  The instructions for this can be found [here](../initiatives/submit_initiative_instructions.md)
 
 - **Peer Nomination**  
   Any existing Fellow can nominate a candidate by contacting the Secretary.


### PR DESCRIPTION
Refferring to: #22 
All I did was basically remove the form from the path to fellowship and replace it with the instructions.  This is probably moot anyway because the instructions for fellowship will be outward facing and therefore on the website