### PR TITLE
Add reference links to the ONR initative doc

### DIFF
--- a/docs/initiatives/in-progress/peer_review_program.md
+++ b/docs/initiatives/in-progress/peer_review_program.md
@@ -67,3 +67,7 @@ _Hypothesis:_ We believe that a structured peer review process will increase the
 
 - [GitHub Issue](https://github.com/open-neuromorphic/communications/issues/65)
 - [Docs or Files](https://github.com/open-neuromorphic/communications/tree/main/docs/initiatives)
+- [OpenReview Venue](https://openreview.net/group?id=ONR)
+- [Submitter Guide](https://open-neuromorphic.org/neuromorphic-computing/research/guide/submitter-guide/)
+- [Reviewer Guide](https://open-neuromorphic.org/neuromorphic-computing/research/guide/reviewer-guide/)
+- [Reviewer Criteria](https://open-neuromorphic.org/neuromorphic-computing/research/guide/review-criteria/)


### PR DESCRIPTION
Links to: #85 
Add reference links to ONR initiative doc.  They don't work yet because we haven't merged the ONR content yet but they will be correct.