### PR TITLE
Policy: establish policy for organizational data and asset ownership

### DIFF
--- a/docs/policies/data_ownership_policy.md
+++ b/docs/policies/data_ownership_policy.md
@@ -1,0 +1,33 @@
+# Open Neuromorphic (ONM) Organizational Data & Asset Ownership Policy
+
+## 1. Preamble & Purpose
+Open Neuromorphic (ONM) operates on the principles of open science, transparency, and collaborative governance. To ensure operational continuity, and maintain verifiable records, it is imperative that all core organizational data belongs to the organization itself, not to any individual member.
+
+This policy explicitly defines the ownership, hosting, and transfer requirements for all official ONM documentation, voting records, financial agreements, and community assets.
+
+## 2. Designated Primary Accounts
+The "Designated Primary Accounts" serve as the sole authoritative and administrative owners of ONM infrastructure. Currently, these are defined as:
+*   **The ONM Administrative Email & Workspace:** `open.neuromorphic@gmail.com` (and its associated Google Drive, Forms, and Analytics properties).
+*   **The ONM GitHub Organization:** `github.com/open-neuromorphic`
+
+## 3. Data Ownership Mandates
+To maintain the integrity of ONM’s operations, the Executive Committee (EC) and all active Voting Members must adhere to the following mandates:
+
+*   **3.1. Official Account Origination:** All official governance documents, membership rosters, election forms (e.g., Google Forms used for voting), financial records, and operational assets **must be created, hosted, and owned by a Designated Primary Account.**
+*   **3.2. Prohibition of Personal Ownership:** Under no circumstances shall sole administrative ownership or the primary hosting of critical organizational data reside on a personal, private, or academic account of any single community member, founder, or EC officer.
+*   **3.3. Raw Data Retention for Elections:** The ONM Charter requires the Operations Chair to maintain an active membership and Voting Membership roll based on meeting attendance and voting participation. Therefore, **raw data exports and complete audit trails** of all ONM elections, confirmations, and resolutions must be retained by the EC. Curated summaries or aggregated minutes are insufficient for governance auditing purposes and do not replace the requirement to surrender raw source data.
+
+## 4. Legacy Data, Disclosure, and Transition of Power
+ONM recognizes that in its early stages, some organizational assets may have been created on personal accounts. However, organizational data is the property of the ONM community.
+
+*   **4.1. Mandatory Transfer:** Any official ONM data—including historical election forms, voting records, passwords, and external platform administration rights—currently hosted on a personal account must be transferred to the Designated Primary Account immediately upon the request of the sitting Executive Committee.
+*   **4.2. Transition of EC Officers:** Upon the conclusion of an EC member's term, they are required to initiate a full handover of all operational data, credentials, and raw historical records to the incoming EC within **14 days**.
+
+## 5. Enforcement and Escalation
+Withholding organizational records from the sitting Executive Committee severely obstructs the EC’s ability to fulfill its Charter-mandated duties (such as verifying quorum, maintaining the Voting Member roll, and executing legal/financial due diligence).
+
+If an individual refuses to provide full access to or raw exports of requested historical organizational data (such as past election forms or financial transcripts), the EC will treat this as a breach of ONM’s transparency and governance standards.
+
+The EC reserves the right to escalate willful data withholding to the Voting Members for disciplinary action, which may result in:
+1. The immediate suspension of the individual's voting privileges.
+2. Removal from the active Voting Member roll until the requested organizational data is surrendered to the Designated Primary Account.


### PR DESCRIPTION
This PR establishes a formal policy ensuring that all critical ONM infrastructure, voting records, and governance documents are hosted on and owned by the official ONM primary accounts (e.g., open.neuromorphic@gmail.com).
Why is this needed? The current EC has been blocked from executing our Charter-mandated duty to track active Voting Member participation because the raw Google Forms data from the February 2026 voting member elections was hosted on a personal account and the raw export has not been handed over to the current EC despite multiple requests. This policy closes that loophole, explicitly requires the transfer of legacy voting data, and protects the organization's operational continuity moving forward.