### PR TITLE
charter: allow non-Voting Members to run for EC positions

### DIFF
--- a/docs/ONM-Organisational-Charter.md
+++ b/docs/ONM-Organisational-Charter.md
@@ -68,7 +68,7 @@ Decisions involving structure, major partnerships, or long-term initiatives requ
 
 ## Elections and Terms
 
-Elections to the core leadership team occur **every year**, typically at a GM or via an online voting process. Members may nominate themselves or others. All active members are eligible to vote, and results are determined by simple majority.
+Elections to the core leadership team occur **every year**, typically at a GM or via an online voting process. Members may nominate themselves or others. All active members are eligible to vote, and results are determined by simple majority. Executive Committee officers do not need to be ONM Voting Members at the time of election, but they must be active participants in the ONM community or active members.
 
 Each elected officer begins a new one-year term upon confirmation. There are no term limits, but re-election is required.
 
@@ -108,7 +108,7 @@ ONM maintains a Code of Conduct that outlines expectations for respectful partic
 
 ## Adoption of the Charter
 
-This charter was adopted on \[Insert Date\] to formalise the structure and guiding principles of Open Neuromorphic. It reflects our commitment to an open, dynamic, and inclusive community.
+This charter was adopted on [Insert Date] to formalise the structure and guiding principles of Open Neuromorphic. It reflects our commitment to an open, dynamic, and inclusive community.
 
 **Signed:**
 


### PR DESCRIPTION
## Summary
This PR implements the tabled AGM proposal regarding candidate eligibility. It clarifies that candidates running for the Executive Committee (EC) do not need to be pre-existing active Voting Members, provided they are active participants in the community or general members.

## Context
This approach keeps the general growth of the active Voting Member pool separate from the annual election of operational officers, allowing the community to select qualified leaders from the broader ecosystem.

## Related Issues
- Part of #130 (Track B, Proposal A)

## Conflicts
-  #141