### PR TITLE
charter: establish dispute escalation process to Voting Members

### DIFF
--- a/docs/ONM-Organisational-Charter.md
+++ b/docs/ONM-Organisational-Charter.md
@@ -74,6 +74,8 @@ Each elected officer begins a new one-year term upon confirmation. There are no 
 
 If a majority of the Core Leadership Team believes that an officer is no longer actively participating in ONM, they may initiate a re-evaluation process. This entails calling for a new election for that officer’s role, which will be conducted using the standard nomination and voting procedures.
 
+Any dispute arising within the Core Leadership Team that remains unresolved after reasonable deliberation shall be referred to the active Membership body for a decisive vote within 14 days, provided at least two of the three officers vote to initiate the escalation.
+
 ## General Meeting (GM)
 
 A GM is held at least once per year and includes:
@@ -108,7 +110,7 @@ ONM maintains a Code of Conduct that outlines expectations for respectful partic
 
 ## Adoption of the Charter
 
-This charter was adopted on \[Insert Date\] to formalise the structure and guiding principles of Open Neuromorphic. It reflects our commitment to an open, dynamic, and inclusive community.
+This charter was adopted on [Insert Date] to formalise the structure and guiding principles of Open Neuromorphic. It reflects our commitment to an open, dynamic, and inclusive community.
 
 **Signed:**
 


### PR DESCRIPTION
## Summary
This PR implements the tabled AGM proposal establishing a formal dispute resolution process. It allows the Executive Committee (EC) to escalate unresolved internal stalemates to the broader body of active Voting Members for a definitive vote.

## Context
This mechanism prevents administrative lockups or gridlock within the Core Leadership Team. If a dispute cannot be resolved internally after sufficient attempts, any 2/3 majority of the EC can vote to refer the matter to the active Voting Members for a final, binding decision. This process must be completed within 14 days of escalation.

## Related Issues
- Part of #130 (Track B, Proposal D)